### PR TITLE
Update Dependency

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "typelift/Operadics" "v0.1.2"
-github "typelift/SwiftCheck" "d45d7023fa93c51292079c159ff18aa0c1cf5269"
+github "typelift/SwiftCheck" "354140578a6deab234604e298c76e262ad456f6e"


### PR DESCRIPTION
Pulls in the latest version of SwiftCheck per the comments in #31.
