### PR TITLE
Update for Xcode 8 GM

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "typelift/Operadics" "d204bd37580da0a901b587ded4809f81e50a04ee"
-github "typelift/SwiftCheck" "bd5d620660b3fb2356dea89573baa99e7f3c1c28"
+github "typelift/SwiftCheck" "706c8075760a65061161797a380b17bd6bd5d055"

--- a/Sources/Combinators.swift
+++ b/Sources/Combinators.swift
@@ -125,7 +125,7 @@ public func |*| <A, B, C>(o : @escaping (B, B) -> C, f : @escaping (A) -> B) -> 
 /// left to the result of both prior applications.
 ///
 ///    (+) |*| f = { x in { y in f(x) + f(y) } }
-public func on<A, B, C>(_ o : @escaping (B) -> @escaping (B) -> C) -> (@escaping (A) -> B) -> (A) -> (A) -> C {
+public func on<A, B, C>(_ o : @escaping (B) -> (B) -> C) -> (@escaping (A) -> B) -> (A) -> (A) -> C {
 	return { f in { x in { y in o(f(x))(f(y)) } } }
 }
 


### PR DESCRIPTION
@escaping can only be applied to parameters.
