### PR TITLE
Make Operadics constraint looser in SwiftPM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - xcodebuild test -scheme Swiftx | xcpretty -c
         # -- Start iOS --
         # !!!: Make sure desired device name & OS version are suitable for the Xcode version installed on osx_image
-        - iOS_DEVICE_NAME="iPad Pro (12.9 inch)"
+        - iOS_DEVICE_NAME="iPad Pro (12.9-inch)"
         - iOS_RUNTIME_VERSION="10.0"
         # Get simulator identifier for desired device/runtime pair
         - SIMULATOR_ID=$(xcrun instruments -s | grep -o "${iOS_DEVICE_NAME} (${iOS_RUNTIME_VERSION}) \[.*\]" | grep -o "\[.*\]" | sed "s/^\[\(.*\)\]$/\1/")

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
 		Target(name: "Swiftx"),
 	],
 	dependencies: [
-		.Package(url: "https://github.com/typelift/Operadics.git", versions: Version(0,2,2)...Version(0,2,2))
+		.Package(url: "https://github.com/typelift/Operadics.git", majorVersion: 0)
 	]
 )
 


### PR DESCRIPTION
Algebra needs at least 0.2.3 now, so this change is needed to use
Algebra and Swiftx in the same project.